### PR TITLE
Remove redundant `object` inheritance in config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,11 +4,11 @@ import os
 from app.lib.util import strtobool
 
 
-class Features(object):
+class Features:
     pass
 
 
-class Base(object):
+class Base:
     BUILD_VERSION: str = os.environ.get("BUILD_VERSION", "")
     TNA_FRONTEND_VERSION: str = ""
     try:


### PR DESCRIPTION
This PR removes the inheritance of the Python built-in `object` which was needed for "new-style" classes in Python 2.x (see: https://www.geeksforgeeks.org/python/why-do-python-classes-inherit-object/), and classes inherit `object` by default in Python 3.x